### PR TITLE
Replace "host" by "inventory"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A playbook can look like this:
     - yaazkal.bastille
 ```
 
-A host file can look like this (this example overrides all default variables):
+An inventory file can look like this (this example overrides all default variables):
 
 ```yaml
 # File name: hosts.yml


### PR DESCRIPTION
I'd like to suggest replacing "host file" by "inventory" which is the more generic term.