### PR TITLE
Inet6

### DIFF
--- a/templates/etc/pf.conf.j2
+++ b/templates/etc/pf.conf.j2
@@ -13,4 +13,6 @@ rdr-anchor "rdr/*"
 block in all
 pass out quick keep state
 antispoof for $ext_if inet
+
 pass in inet proto tcp from any to any port ssh flags S/SA keep state
+pass in inet6 proto tcp from any to any port ssh flags S/SA keep state

--- a/templates/etc/pf.conf.j2
+++ b/templates/etc/pf.conf.j2
@@ -12,7 +12,9 @@ rdr-anchor "rdr/*"
 
 block in all
 pass out quick keep state
+
 antispoof for $ext_if inet
+antispoof for $ext_if inet6
 
 pass in inet proto tcp from any to any port ssh flags S/SA keep state
 pass in inet6 proto tcp from any to any port ssh flags S/SA keep state


### PR DESCRIPTION
The new rules will allow ine6 traffic passing the pf as well. Preventing accidental lockout/block of connection to target over ipv6. 